### PR TITLE
Remove unused variables pkg

### DIFF
--- a/LibPkgConf.xs
+++ b/LibPkgConf.xs
@@ -168,7 +168,6 @@ path(self)
     my_client_t *self
   INIT:
     pkgconf_node_t *n;
-    pkgconf_pkg_t *pkg;
     pkgconf_path_t *pnode;
     int count = 0;
   CODE:
@@ -185,7 +184,6 @@ filter_lib_dirs(self)
     my_client_t *self
   INIT:
     pkgconf_node_t *n;
-    pkgconf_pkg_t *pkg;
     pkgconf_path_t *pnode;
     int count = 0;
   CODE:
@@ -202,7 +200,6 @@ filter_include_dirs(self)
     my_client_t *self
   INIT:
     pkgconf_node_t *n;
-    pkgconf_pkg_t *pkg;
     pkgconf_path_t *pnode;
     int count = 0;
   CODE:


### PR DESCRIPTION
Building with -Wall reports some unused variable:

```

$ gcc -c   -I/usr/include/pkgconf -DMY_PKGCONF_VERSION=1.3.0 -g   -DVERSION=\"0.06\" -DXS_VERSION=\"0.06\" -fPIC "-I/usr/lib64/perl5/CORE"   LibPkgConf.c -Wall
LibPkgConf.c: In function ‘XS_PkgConfig__LibPkgConf__Client__init’:
LibPkgConf.c:248:7: warning: unused variable ‘args’ [-Wunused-variable]
  SV * args = ST(1)
       ^~~~
LibPkgConf.c: In function ‘XS_PkgConfig__LibPkgConf__Client_path’:
LibPkgConf.xs:171:20: warning: unused variable ‘pkg’ [-Wunused-variable]
     pkgconf_pkg_t *pkg;
                    ^~~
LibPkgConf.c: In function ‘XS_PkgConfig__LibPkgConf__Client_filter_lib_dirs’:
LibPkgConf.xs:188:20: warning: unused variable ‘pkg’ [-Wunused-variable]
     pkgconf_pkg_t *pkg;
                    ^~~
LibPkgConf.c: In function ‘XS_PkgConfig__LibPkgConf__Client_filter_include_dirs’:
LibPkgConf.xs:205:20: warning: unused variable ‘pkg’ [-Wunused-variable]
     pkgconf_pkg_t *pkg;
                    ^~~
LibPkgConf.c: In function ‘XS_PkgConfig__LibPkgConf__Package__get_variable’:
LibPkgConf.c:1053:16: warning: variable ‘client’ set but not used [-Wunused-but-set-variable]
  my_client_t * client;
                ^~~~~~
```

This pulll request removes the obviously useless pkgconf_pkg_t *pkg definitions.

Unfortunately my XS knowledge is not good enough to deal with the first and last warning that comes from unused _init() and _get_variable() arguments in a generated code.